### PR TITLE
Support named objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ test {
     )
 }
 
-version  = "1.5.1"
+version  = "1.5.2"
 group = "com.zeroc.gradle.ice-builder"
 
 if(!localOnly.toBoolean()) {

--- a/src/main/groovy/com/zeroc/gradle/icebuilder/slice/SliceExtension.groovy
+++ b/src/main/groovy/com/zeroc/gradle/icebuilder/slice/SliceExtension.groovy
@@ -267,9 +267,13 @@ class SliceExtension {
         this.java = java
     }
 
-    void java(Action<? super Java> action) {
-        def defaultJava = java.maybeCreate("default")
-        action.execute(defaultJava)
+    void java(Action<? super NamedDomainObjectContainer<Java>> action) {
+        try {
+            action.execute(java);
+        } catch (MissingPropertyException e) {
+            def defaultJava = java.maybeCreate("default");
+            action.execute(defaultJava);
+        }
     }
 
     private def parseVersion(v) {


### PR DESCRIPTION
With the fixes to support Kotlin in 1.5.1 https://github.com/zeroc-ice/ice-builder-gradle/commit/c975246a7a3ad8346a6dcf4f87e79c08893e0b41 break support to configure multiple Slice file sets. This PR fixes the code to keep Kotlin support and allow using multiple Slice file sets.